### PR TITLE
商品削除機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: %i[new create edit update]
-  before_action :set_item, only: %i[show edit update]
-  before_action :ensure_owner, only: %i[edit update]
+  before_action :authenticate_user!, only: %i[new create edit update destroy]
+  before_action :set_item, only: %i[show edit update destroy]
+  before_action :ensure_owner, only: %i[edit update destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
     @item = current_user.items.build(item_params)
 
     if @item.save
-      redirect_to root_path, notice: '商品を出品しました'
+      redirect_to root_path, notice: t('items.create.success')
     else
       render :new, status: :unprocessable_entity
     end
@@ -31,10 +31,15 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to item_path(@item), notice: '商品情報を更新しました'
+      redirect_to item_path(@item), notice: t('items.update.success')
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path, notice: t('items.destroy.success')
   end
 
   private
@@ -51,6 +56,6 @@ class ItemsController < ApplicationController
   def ensure_owner
     return if @item.user_id == current_user.id
 
-    redirect_to root_path, alert: '商品の編集権限がありません'
+    redirect_to root_path, alert: t('items.edit.no_permission')
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -62,7 +62,6 @@
   </div>
   <%# /FURIMAが選ばれる3つの理由部分 %>
 
-  <%# 画面中央の「会員数日本一位」帯部分 %>
   <div class='ad-contents'>
     <h2 class='ad-title'>
       会員数日本一位
@@ -81,9 +80,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
 
-  <%# FURIMAの特徴 %>
   <div class='feature-contents'>
     <h2 class='title'>
       FURIMAの特徴
@@ -118,9 +115,7 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
@@ -134,13 +129,6 @@
             <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
-
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <%# <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div> %>
-              <%# //商品が売れていればsold outを表示しましょう %>
-
             </div>
             <div class='item-info'>
               <h3 class='item-name'>
@@ -158,7 +146,6 @@
           </li>
         <% end %>
       <% else %>
-        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,7 +166,6 @@
       <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,9 @@
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-img" %>
       
-      <%# 商品が売れていればsold outを表示しましょう %>
       <%# <div class='sold-out'>
         <span>Sold Out!!</span>
       </div> %>
-      <%# //商品が売れていればsold outを表示しましょう %>
       
     </div>
     <div class="item-price-box">
@@ -28,7 +26,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete, confirm: "本当に削除しますか？" }, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,8 +26,8 @@ module Furima46385
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # デフォルトロケールを英語に設定
-    config.i18n.default_locale = :en
+    # デフォルトロケールを日本語に設定
+    config.i18n.default_locale = :ja
 
     # Basic認証の環境変数設定
     config.basic_auth_user = ENV['BASIC_AUTH_USER'] || 'admin'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  items:
+    create:
+      success: "商品を出品しました"
+    update:
+      success: "商品情報を更新しました"
+    destroy:
+      success: "商品を削除しました"
+    edit:
+      no_permission: "商品の編集権限がありません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root 'items#index'
 
-  resources :items, only: %i[index new create show edit update]
+  resources :items, only: %i[index new create show edit update destroy]
 end


### PR DESCRIPTION
# What
 商品削除機能を実装

# Why
- ItemsControllerにdestroyアクションを追加
- 商品詳細画面に削除ボタンを追加（ログイン状態の出品者のみ表示）
- 削除権限チェックを実装（ensure_owner）
- 削除完了後はトップページにリダイレクト
- 日本語ロケールファイルを作成し、メッセージを国際化
- 実装済みのコメントアウトを削除

# 挙動の確認
https://gyazo.com/eaa3f7b037eb342cd369c9f2dba99ca1